### PR TITLE
Fixed chrome address bug

### DIFF
--- a/chrome/popup.js
+++ b/chrome/popup.js
@@ -11,7 +11,7 @@ function fetchdata(){
   req.send();
   req.onload = function(){
   res = JSON.parse(req.responseText);
-  problemurl = "http://www.spoj.com/problems/" + res.RandomProblemCode.Code
+  problemurl = "http://www.spoj.com" + res.RandomProblemCode.Code
   chrome.tabs.create({url: problemurl})
   };
 


### PR DESCRIPTION
Currently the address used is http://www.spoj.com/problems//problems/[ProblemCode], resulting in an error when trying to navigate to this address. The fix removes the redundant problems and extra slash -- giving the correct address of  http://www.spoj.com/problems/[ProblemCode]
